### PR TITLE
Fix: baseUrl 설정을 통한 alias 호출 오류 해결

### DIFF
--- a/bid-weather/tsconfig.json
+++ b/bid-weather/tsconfig.json
@@ -18,6 +18,8 @@
         "name": "next"
       }
     ],
+
+    "baseUrl": ".",
     "paths": {
       "@/*": ["src/*"]
     }


### PR DESCRIPTION
## 📌 Key Changes

<!-- Briefly describe the purpose of this PR and what problem it solves. -->
- `tsconfig.json`에 `baseUrl` 및 `paths` 설정 추가하여 `@` alias 적용  
- 기존 상대 경로(`../`) import를 절대 경로(`@/`)로 변경  
- 빌드 시 발생하던 경로 에러 해결  


---

## 🔍 Before & After

<!-- If applicable, attach screenshots, GIFs, or code snippets to show the changes. -->

**Before**
```tsx
import RainfallChart from "../components/RainfallChart";
```
**After**
```tsx
import RainfallChart from "@/components/RainfallChart";
```
---

## ✅ Checklist

- [x] alias 설정 정상 동작 확인
- [x] 빌드 에러 해결 확인
