### PR TITLE
Feat/main page chart components UI 개선

### DIFF
--- a/bid-weather/next.config.ts
+++ b/bid-weather/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
   turbopack: {
     rules: {
       "*.svg": {
-        loaders: ["@svgr/webpack"],
+        loaders: [require.resolve("@svgr/webpack")],
         as: "*.js",
       },
     },

--- a/bid-weather/src/app/layout.tsx
+++ b/bid-weather/src/app/layout.tsx
@@ -14,6 +14,9 @@ const pretendard = localFont({
 export const metadata: Metadata = {
   title: "BidWeather",
   description: "입찰 공고 날씨 분석 서비스",
+  icons: {
+    icon: "/logo.svg",
+  },
 };
 
 export default function RootLayout({

--- a/bid-weather/src/components/Bidcalendar.tsx
+++ b/bid-weather/src/components/Bidcalendar.tsx
@@ -115,7 +115,7 @@ export default function BidCalendar() {
   };
 
   return (
-    <div className="bg-white rounded-2xl p-5">
+    <div className="bg-white rounded-2xl p-5 h-[400px]">
       {/* Month navigation */}
       <div className="flex items-center gap-3 mb-3">
         <button

--- a/bid-weather/src/components/Bidcalendar.tsx
+++ b/bid-weather/src/components/Bidcalendar.tsx
@@ -32,23 +32,8 @@ const bidCounts: Record<string, number> = {
   "2026-04-28": 28,
   "2026-04-29": 30,
   "2026-04-30": 31,
-  "2026-05-03": 3,
-  "2026-05-04": 4,
-  "2026-05-05": 5,
-  "2026-05-06": 6,
-  "2026-05-07": 7,
-  "2026-05-08": 8,
-  "2026-05-09": 9,
-  "2026-05-10": 10,
-  "2026-05-11": 11,
-  "2026-05-12": 12,
-  "2026-05-13": 13,
-  "2026-05-14": 14,
-  "2026-05-15": 15,
-  "2026-05-16": 16,
 };
 
-// Intensity: 0=none, 1=light, 2=medium, 3=dark
 function getIntensity(count: number | undefined): 0 | 1 | 2 | 3 {
   if (!count) return 0;
   if (count < 8) return 1;
@@ -56,7 +41,7 @@ function getIntensity(count: number | undefined): 0 | 1 | 2 | 3 {
   return 3;
 }
 
-const intensityClasses: Record<0 | 1 | 2 | 3, string> = {
+const intensityClasses = {
   0: "bg-transparent text-gray-400",
   1: "bg-blue-200 text-blue-700",
   2: "bg-blue-400 text-white",
@@ -83,23 +68,35 @@ export default function BidCalendar() {
   const daysInMonth = getDaysInMonth(year, month);
   const firstDay = getFirstDayOfMonth(year, month);
 
-  // Build calendar grid (6 rows x 7 cols)
   const cells: { day: number; month: "prev" | "cur" | "next" }[] = [];
 
-  // Previous month fill
+  // 이전 달
   const prevMonthDays = getDaysInMonth(year, month - 1);
   for (let i = firstDay - 1; i >= 0; i--) {
     cells.push({ day: prevMonthDays - i, month: "prev" });
   }
-  // Current month
+
+  // 현재 달
   for (let d = 1; d <= daysInMonth; d++) {
     cells.push({ day: d, month: "cur" });
   }
-  // Next month fill
+
+  // 다음 달 채우기 (최대 42칸)
   const remaining = 42 - cells.length;
   for (let d = 1; d <= remaining; d++) {
     cells.push({ day: d, month: "next" });
   }
+
+  // 주 단위로 쪼개기
+  const weeks = [];
+  for (let i = 0; i < 42; i += 7) {
+    weeks.push(cells.slice(i, i + 7));
+  }
+
+  // 마지막 주가 전부 다음달이면 제거
+  const lastWeek = weeks[weeks.length - 1];
+  const isAllNext = lastWeek.every((cell) => cell.month === "next");
+  if (isAllNext) weeks.pop();
 
   const prevMonth = () => {
     if (month === 0) {
@@ -107,6 +104,7 @@ export default function BidCalendar() {
       setMonth(11);
     } else setMonth((m) => m - 1);
   };
+
   const nextMonth = () => {
     if (month === 11) {
       setYear((y) => y + 1);
@@ -115,12 +113,12 @@ export default function BidCalendar() {
   };
 
   return (
-    <div className="bg-white rounded-2xl p-5 h-[400px]">
-      {/* Month navigation */}
+    <div className="bg-white rounded-2xl p-5 h-[400px] flex flex-col">
+      {/* 상단 */}
       <div className="flex items-center gap-3 mb-3">
         <button
           onClick={prevMonth}
-          className="w-7 h-7 rounded-full hover:bg-gray-100 flex items-center justify-center text-gray-500 transition"
+          className="w-7 h-7 rounded-full hover:bg-gray-100 flex items-center justify-center text-gray-500"
         >
           ‹
         </button>
@@ -129,75 +127,77 @@ export default function BidCalendar() {
         </span>
         <button
           onClick={nextMonth}
-          className="w-7 h-7 rounded-full hover:bg-gray-100 flex items-center justify-center text-gray-500 transition"
+          className="w-7 h-7 rounded-full hover:bg-gray-100 flex items-center justify-center text-gray-500"
         >
           ›
         </button>
       </div>
 
-      {/* Weekday headers */}
+      {/* 요일 */}
       <div className="grid grid-cols-7 mb-1">
         {WEEKDAYS.map((wd) => (
-          <div
-            key={wd}
-            className="text-center text-[11px] font-medium text-gray-400 py-1"
-          >
+          <div key={wd} className="text-center text-[11px] text-gray-400 py-1">
             {wd}
           </div>
         ))}
       </div>
 
-      {/* Day grid */}
-      <div className="grid grid-cols-7 gap-y-1">
-        {cells.map((cell, idx) => {
-          const isCur = cell.month === "cur";
-          const key = isCur
-            ? toKey(year, month, cell.day)
-            : cell.month === "next"
-              ? toKey(
-                  month === 11 ? year + 1 : year,
-                  (month + 1) % 12,
-                  cell.day,
-                )
-              : toKey(
-                  month === 0 ? year - 1 : year,
-                  (month - 1 + 12) % 12,
-                  cell.day,
-                );
+      {/* 날짜 */}
+      <div className="flex flex-col gap-y-1 flex-1">
+        {weeks.map((week, wIdx) => (
+          <div key={wIdx} className="grid grid-cols-7">
+            {week.map((cell, idx) => {
+              const isCur = cell.month === "cur";
 
-          const count = bidCounts[key];
-          const intensity = isCur ? getIntensity(count) : 0;
-          const isToday =
-            isCur &&
-            cell.day === today.getDate() &&
-            month === today.getMonth() &&
-            year === today.getFullYear();
+              const key = isCur
+                ? toKey(year, month, cell.day)
+                : cell.month === "next"
+                  ? toKey(
+                      month === 11 ? year + 1 : year,
+                      (month + 1) % 12,
+                      cell.day,
+                    )
+                  : toKey(
+                      month === 0 ? year - 1 : year,
+                      (month - 1 + 12) % 12,
+                      cell.day,
+                    );
 
-          return (
-            <div key={idx} className="flex flex-col items-center py-[2px]">
-              {/* Date number row */}
-              <span
-                className={`text-[11px] mb-[2px] ${
-                  isCur ? "text-gray-500" : "text-gray-300"
-                }`}
-              >
-                {cell.day}
-              </span>
-              {/* Circle badge */}
-              {isCur && count ? (
-                <div
-                  className={`w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-semibold transition-all ${intensityClasses[intensity]} ${
-                    isToday ? "ring-2 ring-blue-400 ring-offset-1" : ""
-                  }`}
-                >
-                  {count}
+              const count = bidCounts[key];
+              const intensity = isCur ? getIntensity(count) : 0;
+
+              const isToday =
+                isCur &&
+                cell.day === today.getDate() &&
+                month === today.getMonth() &&
+                year === today.getFullYear();
+
+              return (
+                <div key={idx} className="flex flex-col items-center py-[2px]">
+                  <span
+                    className={`text-[11px] mb-[2px] ${
+                      isCur ? "text-gray-500" : "text-gray-300"
+                    }`}
+                  >
+                    {cell.day}
+                  </span>
+
+                  {isCur && count ? (
+                    <div
+                      className={`w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-semibold ${
+                        intensityClasses[intensity]
+                      } ${isToday ? "ring-2 ring-blue-400 ring-offset-1" : ""}`}
+                    >
+                      {count}
+                    </div>
+                  ) : (
+                    <div className="w-7 h-7" />
+                  )}
                 </div>
-              ) : (
-                <div className="w-7 h-7" />
-              )}
-            </div>
-          );
-        })}
+              );
+            })}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/bid-weather/src/components/RainfallChart.tsx
+++ b/bid-weather/src/components/RainfallChart.tsx
@@ -36,7 +36,7 @@ export default function RainfallChart() {
       <div className="flex gap-0">
         {/* Y-axis labels */}
         <div
-          className="flex flex-col justify-between pr-2 text-[11px] text-gray-400 text-right shrink-0"
+          className="flex flex-col gap-5 pr-3 text-[11px] text-gray-400 text-right shrink-0"
           style={{ height: `${BAR_MAX_HEIGHT}px`, paddingBottom: "0px" }}
         >
           {["많음", "보통", "적음", " "].map((label) => (
@@ -45,10 +45,20 @@ export default function RainfallChart() {
         </div>
 
         {/* Chart area */}
-        <div className="flex-1 flex flex-col">
+        <div className="flex-1 flex flex-col relative">
+          {/* grid lines */}
+          <div className="absolute inset-0 pointer-events-none z-0">
+            {[7, 37, 67].map((top, i) => (
+              <div
+                key={i}
+                className="absolute w-full border-t border-gray-200"
+                style={{ top: `${top}%` }}
+              />
+            ))}
+          </div>
           {/* Bars */}
           <div
-            className="flex items-end gap-[6px] border-b border-gray-100"
+            className="flex items-end gap-[6px] border-b border-gray-100 z-10"
             style={{ height: `${BAR_MAX_HEIGHT}px` }}
           >
             {data.map(({ date, mm }) => {

--- a/bid-weather/src/components/RainfallChart.tsx
+++ b/bid-weather/src/components/RainfallChart.tsx
@@ -12,9 +12,13 @@ const seed = [72, 15, 3, 88, 42, 20, 55];
 
 function generateData(): RainfallData[] {
   const today = new Date();
+
+  const base = new Date(today);
+  base.setDate(today.getDate() - 1);
+
   return Array.from({ length: 7 }, (_, i) => {
-    const d = new Date(today);
-    d.setDate(today.getDate() - (6 - i));
+    const d = new Date(base);
+    d.setDate(base.getDate() - (6 - i));
     const mm = seed[i];
     const level =
       mm >= 70 ? "many" : mm >= 40 ? "normal" : mm >= 15 ? "few" : "none";

--- a/bid-weather/src/components/RainfallChart.tsx
+++ b/bid-weather/src/components/RainfallChart.tsx
@@ -39,7 +39,7 @@ export default function RainfallChart() {
           className="flex flex-col justify-between pr-2 text-[11px] text-gray-400 text-right shrink-0"
           style={{ height: `${BAR_MAX_HEIGHT}px`, paddingBottom: "0px" }}
         >
-          {["많음", "보통", "적음"].map((label) => (
+          {["많음", "보통", "적음", " "].map((label) => (
             <span key={label}>{label}</span>
           ))}
         </div>


### PR DESCRIPTION
## 📌 Key Changes

<!-- Briefly describe the purpose of this PR and what problem it solves. -->

대시보드 내 그래프 및 캘린더 UI를 개선하고, 데이터 시각화의 일관성과 가독성을 향상시키는 작업 수행

**📅 BidCalendar 개선**
- 차트 그래프와 높이 동등하게 수정 
- 마지막 주가 모두 다음 달일 경우 자동 제거
- 5주 기준 우선 표시로 UI 간결화

**🌧 RainfallChart 개선**
- “오늘 제외” 데이터 기준으로 변경 (완료 데이터 기준 7일)
- Y축 라벨 간격 및 위치 조정
- 가로 기준선(grid line) 추가


---


## 🔗 Related Issues

<!-- Link the issues this PR addresses (e.g., Closes #123). -->

- Fixes #5, #7 
---

## 🔍 Before & After

**📅 BidCalendar**
<!-- If applicable, attach screenshots, GIFs, or code snippets to show the changes. -->
| Before | After |
|--------|-------|
| <img width="476" height="226" alt="before" src="https://github.com/user-attachments/assets/3b425567-1d8d-4215-a350-5f4405cb8ba2" /> | <img width="476" height="226" alt="after" src="https://github.com/user-attachments/assets/a4dbd462-068a-4994-b503-23fb3b9c1b47" /> |


**🌧 RainfallChart**
| Before | After |
|--------|-------|
| <img width="692" height="537" alt="before" src="https://github.com/user-attachments/assets/a43d054b-67da-4f0c-a5ae-24408d42b49d" /> | <img width="692" height="537" alt="after" src="https://github.com/user-attachments/assets/bc4377d5-3064-4122-ab2b-84e709281fce" /> |

---