### PR TITLE
Refactor: 지역 필터 제거 및 그래프 예측 범위 수정

### DIFF
--- a/bid-weather/src/components/BidGraph.tsx
+++ b/bid-weather/src/components/BidGraph.tsx
@@ -43,7 +43,7 @@ const generateDummyData = (): ApiDataPoint[] => {
 
   // 예측 데이터 구간
   let predictVal = lastActualValue;
-  for (let i = 0; i < 5; i++) {
+  for (let i = 0; i < 1; i++) {
     predictVal = Math.max(5, predictVal + Math.floor(Math.random() * 20 - 8));
     const period = `${year}-${String(month).padStart(2, "0")}`;
     data.push({ period, actualCount: null, predictCount: predictVal });

--- a/bid-weather/src/components/SearchFilter.tsx
+++ b/bid-weather/src/components/SearchFilter.tsx
@@ -8,7 +8,6 @@ import IcoAngle from "@/assets/icons/Filter/ico_angle.svg";
 export default function SearchFilter() {
   // 선택된 필터 상태 관리 (예시 데이터)
   const [activeFilters, setActiveFilters] = useState([
-    { id: 1, label: "대전광역시" },
     { id: 2, label: "공사" },
     { id: 3, label: "수해/침수 예방" },
   ]);
@@ -28,28 +27,7 @@ export default function SearchFilter() {
       {/* 검색 입력폼 (Search Top Box) */}
       <div className="bg-white rounded-2xl p-6 md:px-8 md:py-5">
         <div className="flex flex-col gap-4">
-          {/* 필터 폼 (Select Boxes) */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-6 w-4/5">
-            <div className="flex items-center gap-3 w-full">
-              <label
-                className="text-[15px] font-bold text-gray-900 shrink-0 w-16"
-                htmlFor="appl-sch-sel1"
-              >
-                지역
-              </label>
-              <div className="relative flex-1">
-                <select
-                  id="appl-sch-sel1"
-                  className="appearance-none w-full h-12 px-4 pr-10 border border-gray-300 rounded-lg bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-blue-600 focus:border-blue-600"
-                >
-                  <option value="">전체</option>
-                  <option value="daejeon">대전광역시</option>
-                  <option value="seoul">서울특별시</option>
-                </select>
-                <IcoAngle className="absolute right-4 top-1/2 -translate-y-1/2 w-6 h-6 text-gray-500 pointer-events-none" />
-              </div>
-            </div>
-
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:gap-6 w-4/5">
             <div className="flex items-center gap-3 w-full">
               <label
                 className="text-[15px] font-bold text-gray-900 shrink-0 w-16"
@@ -132,7 +110,6 @@ export default function SearchFilter() {
           </div>
         </div>
       </div>
-      {/* //검색 입력폼 */}
     </div>
   );
 }


### PR DESCRIPTION
## 📌 Key Changes

- 메인 페이지 필터에서 지역 필터 제거
- 그래프 예측 데이터 범위를 이번 달 기준으로 제한

---

## 🔗 Related Issues

Closes #15 

---

## 🔍 Before & After(Optional)

<img width="1582" height="983" alt="스크린샷 2026-05-03 02 12 31" src="https://github.com/user-attachments/assets/436bb5ed-1c12-4ad8-be42-d4fcb14447c1" />
<img width="1582" height="983" alt="스크린샷 2026-05-03 02 12 33" src="https://github.com/user-attachments/assets/ec7c6116-4d1f-4114-bccc-f4ef1b3a93b7" />


---

## ✅ Checklist

Please make sure the following are true before submitting your PR:

- [x] 지역 필터 제거 및 관련 UI 정상 동작 확인
- [x] 그래프 예측 범위가 이번 달 기준으로 제한되는지 확인
