### PR TITLE
Fix: 메인 페이지 로딩 UI 및 그래프 데이터 표시 오류 수정

### DIFF
--- a/bid-weather/src/components/BidGraph.tsx
+++ b/bid-weather/src/components/BidGraph.tsx
@@ -27,29 +27,35 @@ interface BidGraphProps {
 
 const CustomTooltip = ({ active, payload, label }: any) => {
   if (active && payload && payload.length) {
-    const filteredPayload =
-      payload.length > 1
-        ? payload.filter((p: any) => p.dataKey === "predictCount")
-        : payload;
+    const actualData = payload.find(
+      (p: any) => p.dataKey === "actualCount" && p.value !== null,
+    );
+    const predictData = payload.find(
+      (p: any) => p.dataKey === "predictCount" && p.value !== null,
+    );
+
+    const targetData = actualData || predictData;
+
+    if (!targetData) return null;
 
     return (
       <div className="bg-white p-3 rounded-lg shadow-md border border-gray-100">
         <p className="text-gray-700 font-bold mb-2">{label}</p>
-        {filteredPayload.map((entry: any, index: number) => (
-          <div key={index} className="mb-1 last:mb-0">
-            <p className="text-sm m-0" style={{ color: entry.color }}>
-              {entry.dataKey === "actualCount" ? "실제 데이터" : "예측 데이터"}{" "}
-              : {entry.value.toLocaleString()} 건
-            </p>
-            {entry.payload.partialActual !== undefined &&
-              entry.dataKey === "predictCount" && (
-                <p className="text-xs text-gray-500 mt-1 m-0">
-                  (어제까지 집계: {entry.payload.partialActual.toLocaleString()}{" "}
-                  건)
-                </p>
-              )}
-          </div>
-        ))}
+        <div className="mb-1 last:mb-0">
+          <p className="text-sm m-0" style={{ color: targetData.color }}>
+            {targetData.dataKey === "actualCount"
+              ? "실제 데이터"
+              : "예측 데이터"}{" "}
+            : {targetData.value.toLocaleString()} 건
+          </p>
+          {targetData.payload.partialActual !== undefined &&
+            targetData.dataKey === "predictCount" && (
+              <p className="text-xs text-gray-500 mt-1 m-0">
+                (어제까지 집계:{" "}
+                {targetData.payload.partialActual.toLocaleString()} 건)
+              </p>
+            )}
+        </div>
       </div>
     );
   }

--- a/bid-weather/src/components/BidGraph.tsx
+++ b/bid-weather/src/components/BidGraph.tsx
@@ -54,7 +54,6 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
   } = usePredictionGraph(categoryId, subcategoryId);
 
   const data = useMemo<ApiDataPoint[]>(() => {
-    // rawData나 graphData가 없으면 빈 배열 반환
     if (!rawData || !rawData.graphData) return [];
 
     const processedData = [...rawData.graphData];
@@ -125,7 +124,9 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
             axisLine={false}
             tickLine={false}
             tick={{ fontSize: 12, fill: "#9CA3AF" }}
-            dx={-10}
+            dx={-4}
+            width={70}
+            tickFormatter={(value) => value.toLocaleString()}
           />
 
           <Tooltip

--- a/bid-weather/src/components/BidGraph.tsx
+++ b/bid-weather/src/components/BidGraph.tsx
@@ -17,6 +17,7 @@ interface ApiDataPoint {
   period: string;
   actualCount: number | null;
   predictCount: number | null;
+  partialActual?: number;
 }
 
 interface BidGraphProps {
@@ -35,10 +36,19 @@ const CustomTooltip = ({ active, payload, label }: any) => {
       <div className="bg-white p-3 rounded-lg shadow-md border border-gray-100">
         <p className="text-gray-700 font-bold mb-2">{label}</p>
         {filteredPayload.map((entry: any, index: number) => (
-          <p key={index} className="text-sm m-0" style={{ color: entry.color }}>
-            {entry.dataKey === "actualCount" ? "실제 데이터" : "예측 데이터"} :{" "}
-            {entry.value} 건
-          </p>
+          <div key={index} className="mb-1 last:mb-0">
+            <p className="text-sm m-0" style={{ color: entry.color }}>
+              {entry.dataKey === "actualCount" ? "실제 데이터" : "예측 데이터"}{" "}
+              : {entry.value.toLocaleString()} 건
+            </p>
+            {entry.payload.partialActual !== undefined &&
+              entry.dataKey === "predictCount" && (
+                <p className="text-xs text-gray-500 mt-1 m-0">
+                  (어제까지 집계: {entry.payload.partialActual.toLocaleString()}{" "}
+                  건)
+                </p>
+              )}
+          </div>
         ))}
       </div>
     );
@@ -53,26 +63,43 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
     isError,
   } = usePredictionGraph(categoryId, subcategoryId);
 
-  const data = useMemo<ApiDataPoint[]>(() => {
-    if (!rawData || !rawData.graphData) return [];
+  const { data, splitPoint } = useMemo(() => {
+    if (!rawData || !rawData.graphData) return { data: [], splitPoint: null };
 
-    const processedData = [...rawData.graphData];
+    const processedData: ApiDataPoint[] = rawData.graphData.map((d: any) => ({
+      ...d,
+    }));
+    let splitPeriod: string | null = null;
 
-    let lastActualIndex = -1;
-    for (let i = 0; i < processedData.length; i++) {
-      if (processedData[i].actualCount !== null) {
-        lastActualIndex = i;
+    const currentIndex = processedData.findIndex(
+      (d) => d.actualCount !== null && d.predictCount !== null,
+    );
+
+    if (currentIndex !== -1) {
+      const currentItem = processedData[currentIndex];
+
+      splitPeriod =
+        currentIndex > 0
+          ? processedData[currentIndex - 1].period
+          : currentItem.period;
+
+      const partialActual = currentItem.actualCount || 0;
+      const partialPredict = currentItem.predictCount || 0;
+
+      currentItem.predictCount = partialActual + partialPredict;
+      currentItem.partialActual = partialActual;
+      currentItem.actualCount = null;
+
+      if (
+        currentIndex > 0 &&
+        processedData[currentIndex - 1].actualCount !== null
+      ) {
+        processedData[currentIndex - 1].predictCount =
+          processedData[currentIndex - 1].actualCount;
       }
     }
 
-    if (lastActualIndex !== -1 && lastActualIndex + 1 < processedData.length) {
-      processedData[lastActualIndex] = {
-        ...processedData[lastActualIndex],
-        predictCount: processedData[lastActualIndex].actualCount,
-      };
-    }
-
-    return processedData;
+    return { data: processedData, splitPoint: splitPeriod };
   }, [rawData]);
 
   if (isLoading) {
@@ -90,10 +117,6 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
       </div>
     );
   }
-
-  const splitPoint = data.find(
-    (d) => d.actualCount !== null && d.predictCount !== null,
-  )?.period;
 
   const formatXAxis = (tickItem: any) => {
     if (!tickItem || typeof tickItem !== "string") return "";
@@ -149,6 +172,7 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
             strokeWidth={1.5}
             dot={false}
             activeDot={{ r: 4, fill: "#4B5563", strokeWidth: 0 }}
+            connectNulls={true}
           />
 
           <Line
@@ -158,6 +182,7 @@ export default function BidGraph({ categoryId, subcategoryId }: BidGraphProps) {
             strokeWidth={1.5}
             dot={false}
             activeDot={{ r: 4, fill: "#3B82F6", strokeWidth: 0 }}
+            connectNulls={true}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/bid-weather/src/components/WeeklyWeather.tsx
+++ b/bid-weather/src/components/WeeklyWeather.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from "react";
 import WeatherCard from "./WeatherCard";
 
-// 상태로 관리할 가공된 날씨 데이터 타입
 interface MappedWeather {
   date: string;
   condition: string;
@@ -14,7 +13,11 @@ export default function WeeklyWeather() {
   const [weeklyWeather, setWeeklyWeather] = useState<MappedWeather[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
+  const [isMounted, setIsMounted] = useState(false);
+
   useEffect(() => {
+    setIsMounted(true);
+
     const fetchWeather = async () => {
       try {
         const res = await fetch("/api/v1/weather");
@@ -24,16 +27,13 @@ export default function WeeklyWeather() {
         const mappedData: MappedWeather[] = [7, 6, 5, 4, 3, 2, 1].map((num) => {
           const key = `${num}ago`;
           const rawData = data[key];
-
-          // API 응답이 배열일 경우를 대비한 안전한 접근
           const dayData = Array.isArray(rawData) ? rawData[0] : rawData;
-
           const targetDate = new Date(today);
           targetDate.setDate(today.getDate() - num);
 
           return {
             date: targetDate.getDate().toString(),
-            condition: dayData?.weatherType || "맑음",
+            condition: dayData?.weatherType || "SUNNY",
             max: parseInt(dayData?.maxTemp || "0", 10),
             min: parseInt(dayData?.minTemp || "0", 10),
           };
@@ -50,9 +50,24 @@ export default function WeeklyWeather() {
     fetchWeather();
   }, []);
 
+  if (!isMounted) {
+    return null;
+  }
+
   if (isLoading)
     return (
-      <div className="mt-4 text-gray-500">날씨 정보를 불러오는 중입니다...</div>
+      <div className="grid grid-cols-4 md:grid-cols-7 gap-3 mt-4">
+        {Array.from({ length: 7 }).map((_, idx) => (
+          <div
+            key={idx}
+            className="flex flex-col items-center justify-between p-4 bg-white rounded-xl h-[148px] animate-pulse"
+          >
+            <div className="h-5 w-8 bg-gray-200 rounded mb-1"></div>
+            <div className="w-14 h-14 bg-gray-200 rounded-full my-1"></div>
+            <div className="h-4 w-12 bg-gray-200 rounded mt-2"></div>
+          </div>
+        ))}
+      </div>
     );
 
   return (


### PR DESCRIPTION
## 📌 Key Changes

- 날씨 카드 로딩 중에도 placeholder UI가 유지되도록 스켈레톤 레이아웃 추가
- 그래프 Y축 숫자 포맷 및 표시 영역 수정
- 실제 데이터와 예측 데이터 연결 로직 개선
- 그래프 툴팁에 누적 예측 및 부분 집계 정보 표시 추가
- `connectNulls` 적용으로 그래프 연결 자연스럽게 개선

---

## 🔗 Related Issues

Closes #24

---

## 🔍 Before & After(Optional)

### Before
- 날씨 데이터 로딩 중 카드 레이아웃이 비어 보이는 문제 발생
- 그래프 Y축 숫자가 일부 잘려 보이는 문제 존재
- 예측 데이터 반영 안 됨

### After
- 로딩 중에도 스켈레톤 카드 UI 유지
- Y축 숫자 영역 및 포맷 정상 표시
- 예측 데이터 연결 및 툴팁 정보 개선
<img width="1533" height="553" alt="스크린샷 2026-05-21 19 42 12" src="https://github.com/user-attachments/assets/eeb26059-b27d-4d08-9bf4-bac2ab3d5e0e" />
<img width="591" height="450" alt="스크린샷 2026-05-21 22 40 59" src="https://github.com/user-attachments/assets/4e45508d-4c07-4add-a326-1849aef6a7ca" />

---

## ✅ Checklist

Please make sure the following are true before submitting your PR:

- [x] 날씨 카드 로딩 UI 정상 동작 확인
- [x] 그래프 Y축 숫자 표시 오류 수정 확인
- [x] 실제·예측 데이터 연결 로직 정상 동작 확인
- [x] 그래프 툴팁 정보 표시 확인