### PR TITLE
Fix: 필터 선택 상태에 따른 캘린더 데이터 연동 적용

### DIFF
--- a/bid-weather/src/app/page.tsx
+++ b/bid-weather/src/app/page.tsx
@@ -55,8 +55,10 @@ export default function Home() {
 
         <div>
           <SectionTitle>입찰 공고 건 수 예측 달력</SectionTitle>
-          {/* BidCalendar에도 필터 상태를 전달해 줍니다 */}
-          <BidCalendar />
+          <BidCalendar
+            categoryId={selectedCategory}
+            subcategoryId={selectedSubCategory}
+          />
         </div>
       </div>
     </>


### PR DESCRIPTION
## 📌 Key Changes

- 선택된 대분류/소분류 필터 상태를 `BidCalendar` 컴포넌트에 props로 전달
- 필터 변경 시 캘린더 데이터가 동적으로 재조회되도록 수정
- React Query 기반 캘린더 데이터 연동 흐름 연결

---

## 🔗 Related Issues

Closes #26 

---

## 🔍 Before & After(Optional)

### Before
- 필터를 변경해도 캘린더 데이터가 갱신되지 않음
- 캘린더가 고정 데이터처럼 동작함

### After
- 필터 변경 시 캘린더 데이터가 함께 갱신됨
- 선택된 필터 상태에 맞는 데이터 표시 가능

---

## ✅ Checklist

Please make sure the following are true before submitting your PR:

- [x] 필터 상태 props 전달 확인
- [x] 필터 변경 시 캘린더 데이터 재조회 확인
- [x] 캘린더 렌더링 정상 동작 확인